### PR TITLE
fix(): Fixed IP alloc after nse restart

### DIFF
--- a/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam_test.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam_test.go
@@ -1,0 +1,84 @@
+package vl3
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestAlloc(t *testing.T) {
+	var vl3Ipam vl3IPAM
+	vl3Ipam.reset(context.Background(), "10.6.16.0/20", []string{"192.168.0.0/16", "10.1.0.0/16"})
+	ipNet, err := vl3Ipam.allocate()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if ipNet.String() != "10.6.16.1/32" {
+		t.Errorf("Incorrect IP address allocated. Expected: %v, Got: %v", "10.6.16.1/32", ipNet.String())
+	}
+}
+
+func TestAllocIPString(t *testing.T) {
+	var vl3Ipam vl3IPAM
+	vl3Ipam.reset(context.Background(), "10.6.16.0/20", []string{"192.168.0.0/16", "10.1.0.0/16"})
+	ipNet, err := vl3Ipam.allocateIPString("10.6.16.7/32")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if ipNet.String() != "10.6.16.7/32" {
+		t.Errorf("Incorrect IP address allocated. Expected: %v, Got: %v", "10.6.16.7/32", ipNet.String())
+	}
+	ipNet, err = vl3Ipam.allocateIPString("10.6.16.7/32")
+	if err == nil {
+		t.Errorf("Allocating previously allocated IP")
+	}
+}
+
+func TestAllocAndFreeIPSet(t *testing.T) {
+	var vl3Ipam vl3IPAM
+	vl3Ipam.reset(context.Background(), "10.6.16.0/20", []string{"192.168.0.0/16", "10.1.0.0/16"})
+	for i := 0; i < 10; i++ {
+	        ipNet, err := vl3Ipam.allocate()
+	        if err != nil {
+		        t.Errorf("Unexpected error: %v", err)
+	        }
+		fmt.Printf("Allocated IP: %s\n", ipNet.String())
+	}
+	for i := 0; i < 10; i++ {
+		ip := fmt.Sprintf("10.6.16.%d", i + 1)
+		_, err := vl3Ipam.allocateIPString(ip)
+		if err == nil {
+			t.Errorf("Previously allocated IP %v still available", ip)
+		}
+	}
+
+	vl3Ipam.freeIPListAllocated([]string{"10.6.16.3/32", "10.6.16.5/32", "10.6.16.6/32"})
+	if vl3Ipam.isExcluded("10.6.16.1/32") == false {
+		t.Errorf("Freed wrong IP")
+	}
+	for _, ip := range []string{"10.6.16.3/32", "10.6.16.5/32", "10.6.16.6/32"} {
+                if vl3Ipam.isExcluded(ip) == true {
+			t.Errorf("Failed to free IP: %s", ip)
+	        }
+	}
+}
+
+func TestFreeIfAllocated(t *testing.T) {
+	var vl3Ipam vl3IPAM
+	vl3Ipam.reset(context.Background(), "10.6.16.0/20", []string{"192.168.0.0/16", "10.1.0.0/16"})
+	ipNet, err := vl3Ipam.allocateIPString("10.6.16.7/32")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if ipNet.String() != "10.6.16.7/32" {
+		t.Errorf("Incorrect IP address allocated. Expected: %v, Got: %v", "10.6.16.7/32", ipNet.String())
+	}
+
+	vl3Ipam.freeIfAllocated(ipNet.String())
+
+	if vl3Ipam.isExcluded("10.6.16.7/32") {
+		t.Errorf("Failed to free IP address")
+	}
+}
+
+

--- a/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/server.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/ipam"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
@@ -70,8 +71,27 @@ func (v *vl3Server) Request(ctx context.Context, request *networkservice.Network
 
 	shouldAllocate := len(ipContext.SrcIpAddrs) == 0
 
-	if prevAddress, ok := loadAddress(ctx); ok && !shouldAllocate {
-		shouldAllocate = !v.pool.isExcluded(prevAddress)
+	if !shouldAllocate {
+		prevAddress, ok := loadAddress(ctx)
+		if ok {
+			// TODO: What if the prevAddress is not present in the src address list in the ipContext?
+			// Need to handle that scenario too.
+			shouldAllocate = !v.pool.isExcluded(prevAddress)
+		} else {
+			log.FromContext(ctx).Debugf("Prev addr not loaded, need to allocate")
+			// Loop through the list of src IP addresses and try to allocate all the IPs.
+			// If any allocation fails, free the allocated IPs and do a fresh allocation by setting
+			// the shouldAllocate flag to true.
+			for _, srcAddr := range ipContext.SrcIpAddrs {
+				_, err := v.pool.allocateIPString(srcAddr)
+				if err != nil {
+					log.FromContext(ctx).Errorf("Failed to allocate prev IP: %s. Need to allocate new IPs", srcAddr)
+					v.pool.freeIPListAllocated(ipContext.SrcIpAddrs)
+					shouldAllocate = true
+					break
+				}
+			}
+		}
 	}
 
 	if shouldAllocate {


### PR DESCRIPTION
After the vl3 nse restarts, it gets requests from existing NSCs with the ip context filled out with the ip address that was previously assigned to them. The vl3 nse should reserve those IPs before sending a response. Without doing that, the IP pool is not update and hence any new pod coming up will receive an IP which could be in use by other NSCs.

Fixes "(AM-6798) two different gw pods of different gateways are assigned as same nsmIP External"
