### PR TITLE
fix(): Fixed ip change on token refresh

### DIFF
--- a/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/server.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3/server.go
@@ -86,10 +86,10 @@ func (v *vl3Server) Request(ctx context.Context, request *networkservice.Network
 				_, err := v.pool.allocateIPString(srcAddr)
 				if err != nil {
 					log.FromContext(ctx).Errorf("Failed to allocate prev IP: %s. Need to allocate new IPs", srcAddr)
-					v.pool.freeIPListAllocated(ipContext.SrcIpAddrs)
 					shouldAllocate = true
 					break
 				}
+				storeAddress(ctx, srcAddr)
 			}
 		}
 	}


### PR DESCRIPTION
The ip address allocation was not being stored in the ctx Map causing change in IP address allocation when cmd-nsc in the nsc pod resends a networkservice request with refreshed tokens.